### PR TITLE
Improve drag-and-drop positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The server stores tasks in a local `tasks.json` file. The file will be created a
 - Four quadrants: **DO NOW**, **PLAN**, **DELEGATE**, and **ELIMINATE**
 - Add tasks to any quadrant
 - Drag and drop tasks between quadrants
+- Reorder tasks within a quadrant using drag and drop
 - Delete tasks with the × button
 - Persist tasks to disk using the included Node.js server
 - Clear all tasks via the **Clear All** button

--- a/script.js
+++ b/script.js
@@ -29,12 +29,44 @@ document.addEventListener('DOMContentLoaded', () => {
         list.addEventListener('dragover', e => {
             e.preventDefault();
             const dragging = document.querySelector('.dragging');
-            if (dragging && e.target.classList.contains('task-list')) {
+            if (!dragging) return;
+            const after = getDragAfterElement(list, e.clientY);
+            if (after == null) {
                 list.appendChild(dragging);
+            } else {
+                list.insertBefore(dragging, after);
             }
         });
-        list.addEventListener('drop', saveState);
+
+        list.addEventListener('dragenter', () => {
+            list.parentElement.classList.add('drag-over');
+        });
+
+        list.addEventListener('dragleave', e => {
+            if (!list.contains(e.relatedTarget)) {
+                list.parentElement.classList.remove('drag-over');
+            }
+        });
+
+        list.addEventListener('drop', e => {
+            e.preventDefault();
+            list.parentElement.classList.remove('drag-over');
+            saveState();
+        });
     });
+
+    function getDragAfterElement(list, y) {
+        const items = [...list.querySelectorAll('.task:not(.dragging)')];
+        return items.reduce((closest, child) => {
+            const box = child.getBoundingClientRect();
+            const offset = y - box.top - box.height / 2;
+            if (offset < 0 && offset > closest.offset) {
+                return { offset, element: child };
+            } else {
+                return closest;
+            }
+        }, { offset: Number.NEGATIVE_INFINITY }).element;
+    }
 
     function addTask() {
         const text = input.value.trim();


### PR DESCRIPTION
## Summary
- allow reordering tasks while dragging
- highlight quadrants when items are dragged over
- document new reordering feature

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68555d72e48883209e4990e952c61be3