### PR TITLE
Add drop zone to empty quadrants

### DIFF
--- a/style.css
+++ b/style.css
@@ -206,6 +206,19 @@ h1 {
 .task-list {
     list-style: none;
     padding: 0;
+    min-height: 60px; /* allow dropping when empty */
+    position: relative;
+}
+
+.task-list:empty::before {
+    content: 'Drop tasks here';
+    color: #ccc;
+    font-style: italic;
+    position: absolute;
+    top: 20px;
+    left: 0;
+    right: 0;
+    text-align: center;
 }
 
 .task {


### PR DESCRIPTION
## Summary
- ensure empty quadrants still accept dropped tasks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68555f5729a88320a2431f763996bbc3