### PR TITLE
Add basic authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Thumbs.db
 
 # Task data file
 tasks.json
+users.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm start
 
 Open <http://localhost:3000> in your browser to use the app.
 
-The server stores tasks in a local `tasks.json` file. The file will be created automatically when you first add or modify tasks.
+Create an account via the sign‑up form to start using TaskMatrix. Each user has their own task list stored in `tasks.json` alongside credentials in `users.json`.
 
 ## Features
 
@@ -29,6 +29,7 @@ The server stores tasks in a local `tasks.json` file. The file will be created a
 - Reorder tasks within a quadrant using drag and drop
 - Delete tasks with the × button
 - Persist tasks to disk using the included Node.js server
+- User accounts with sign-up and sign-in
 - Clear all tasks via the **Clear All** button
 - Print-friendly view via the **Print** button
 - Responsive design for desktop and mobile devices

--- a/index.html
+++ b/index.html
@@ -7,7 +7,23 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
+    <div id="auth" class="container" style="display:none;">
+        <h1>TaskMatrix</h1>
+        <div class="task-input">
+            <input type="text" id="signup-user" placeholder="Username" maxlength="30">
+            <input type="password" id="signup-pass" placeholder="Password" maxlength="100">
+            <button class="add-btn" id="signup-btn">Sign Up</button>
+        </div>
+        <div class="task-input">
+            <input type="text" id="login-user" placeholder="Username" maxlength="30">
+            <input type="password" id="login-pass" placeholder="Password" maxlength="100">
+            <button class="add-btn" id="login-btn">Log In</button>
+        </div>
+    </div>
+
+    <button id="logout" class="control-btn" style="display:none;">Log Out</button>
+
+    <div id="matrix" class="container" style="display:none;">
         <h1>Priority vs Urgency Matrix</h1>
 
         <div class="task-input">

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-session": "^1.17.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,12 +1,20 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+const session = require('express-session');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 const TASKS_FILE = path.join(__dirname, 'tasks.json');
+const USERS_FILE = path.join(__dirname, 'users.json');
 
 app.use(express.json());
+app.use(session({
+  secret: 'taskmatrix-secret',
+  resave: false,
+  saveUninitialized: false
+}));
 app.use(express.static(__dirname));
 
 function loadTasks() {
@@ -14,28 +22,80 @@ function loadTasks() {
     try {
       return JSON.parse(fs.readFileSync(TASKS_FILE, 'utf8'));
     } catch (_) {
-      return { 'do-now': [], 'plan': [], 'delegate': [], 'eliminate': [] };
+      return {};
     }
   }
-  return { 'do-now': [], 'plan': [], 'delegate': [], 'eliminate': [] };
+  return {};
 }
 
 function saveTasks(tasks) {
   fs.writeFileSync(TASKS_FILE, JSON.stringify(tasks, null, 2));
 }
 
+function loadUsers() {
+  if (fs.existsSync(USERS_FILE)) {
+    try {
+      return JSON.parse(fs.readFileSync(USERS_FILE, 'utf8'));
+    } catch (_) {
+      return {};
+    }
+  }
+  return {};
+}
+
+function saveUsers(users) {
+  fs.writeFileSync(USERS_FILE, JSON.stringify(users, null, 2));
+}
+
+app.get('/api/me', (req, res) => {
+  res.json({ user: req.session.user || null });
+});
+
+app.post('/api/signup', (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) return res.status(400).end();
+  const users = loadUsers();
+  if (users[username]) return res.status(400).end();
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  users[username] = hash;
+  saveUsers(users);
+  req.session.user = username;
+  res.status(201).end();
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) return res.status(400).end();
+  const users = loadUsers();
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  if (users[username] !== hash) return res.status(401).end();
+  req.session.user = username;
+  res.status(204).end();
+});
+
+app.post('/api/logout', (req, res) => {
+  req.session.destroy(() => res.status(204).end());
+});
+
 app.get('/api/tasks', (req, res) => {
-  res.json(loadTasks());
+  if (!req.session.user) return res.status(401).end();
+  const tasks = loadTasks();
+  res.json(tasks[req.session.user] || { 'do-now': [], 'plan': [], 'delegate': [], 'eliminate': [] });
 });
 
 app.post('/api/tasks', (req, res) => {
-  saveTasks(req.body);
+  if (!req.session.user) return res.status(401).end();
+  const tasks = loadTasks();
+  tasks[req.session.user] = req.body;
+  saveTasks(tasks);
   res.status(204).end();
 });
 
 app.delete('/api/tasks', (req, res) => {
-  const empty = { 'do-now': [], 'plan': [], 'delegate': [], 'eliminate': [] };
-  saveTasks(empty);
+  if (!req.session.user) return res.status(401).end();
+  const tasks = loadTasks();
+  tasks[req.session.user] = { 'do-now': [], 'plan': [], 'delegate': [], 'eliminate': [] };
+  saveTasks(tasks);
   res.status(204).end();
 });
 


### PR DESCRIPTION
## Summary
- add express-session dependency and ignore new data files
- implement signup, login and logout routes
- store tasks per user and hash credentials in users.json
- add login/signup forms and logout button to UI
- handle authentication logic in `script.js`
- document new auth workflow in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685562d1e2108320862ea4ad523ab36b