### PR TITLE
Unify sign up/login form

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,11 @@
     <div id="auth" class="container" style="display:none;">
         <h1>TaskMatrix</h1>
         <div class="task-input">
-            <input type="text" id="signup-user" placeholder="Username" maxlength="30">
-            <input type="password" id="signup-pass" placeholder="Password" maxlength="100">
-            <button class="add-btn" id="signup-btn">Sign Up</button>
+            <input type="text" id="auth-user" placeholder="Username" maxlength="30">
+            <input type="password" id="auth-pass" placeholder="Password" maxlength="100">
+            <button class="add-btn" id="auth-btn">Sign Up</button>
         </div>
-        <div class="task-input">
-            <input type="text" id="login-user" placeholder="Username" maxlength="30">
-            <input type="password" id="login-pass" placeholder="Password" maxlength="100">
-            <button class="add-btn" id="login-btn">Log In</button>
-        </div>
+        <div class="auth-toggle">Already have an account? <a href="#" id="auth-toggle-link">Log In</a></div>
     </div>
 
     <button id="logout" class="control-btn" style="display:none;">Log Out</button>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const signupBtn = document.getElementById('signup-btn');
-    const loginBtn = document.getElementById('login-btn');
+    const authBtn = document.getElementById('auth-btn');
+    const authToggleLink = document.getElementById('auth-toggle-link');
+    let authMode = 'signup';
     const logoutBtn = document.getElementById('logout');
     const authBox = document.getElementById('auth');
     const matrixBox = document.getElementById('matrix');
@@ -22,8 +23,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     printBtn.addEventListener('click', () => window.print());
     clearBtn.addEventListener('click', clearAll);
-    signupBtn.addEventListener('click', signup);
-    loginBtn.addEventListener('click', login);
+    authBtn.addEventListener('click', authSubmit);
+    authToggleLink.addEventListener('click', toggleAuth);
     logoutBtn.addEventListener('click', logout);
 
     const lists = document.querySelectorAll('.task-list');
@@ -168,11 +169,12 @@ document.addEventListener('DOMContentLoaded', () => {
         updateCounts();
     }
 
-    async function signup() {
-        const username = document.getElementById('signup-user').value.trim();
-        const password = document.getElementById('signup-pass').value;
+    async function authSubmit() {
+        const username = document.getElementById('auth-user').value.trim();
+        const password = document.getElementById('auth-pass').value;
         if (!username || !password) return;
-        const res = await fetch('/api/signup', {
+        const url = authMode === 'signup' ? '/api/signup' : '/api/login';
+        const res = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username, password })
@@ -180,16 +182,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (res.ok) checkAuth();
     }
 
-    async function login() {
-        const username = document.getElementById('login-user').value.trim();
-        const password = document.getElementById('login-pass').value;
-        if (!username || !password) return;
-        const res = await fetch('/api/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password })
-        });
-        if (res.ok) checkAuth();
+    function toggleAuth(e) {
+        e.preventDefault();
+        authMode = authMode === 'signup' ? 'login' : 'signup';
+        authBtn.textContent = authMode === 'signup' ? 'Sign Up' : 'Log In';
+        authToggleLink.textContent = authMode === 'signup' ? 'Log In' : 'Sign Up';
     }
 
     async function logout() {

--- a/style.css
+++ b/style.css
@@ -383,3 +383,14 @@ h1 {
     50% { transform: scale(1.05); }
     100% { transform: scale(1); }
 }
+
+.auth-toggle {
+    text-align: center;
+    margin-top: 10px;
+}
+
+.auth-toggle a {
+    color: #667eea;
+    text-decoration: none;
+    font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- create single auth form that toggles between sign up and login
- update JS logic to handle toggle and submit
- add basic styling for auth toggle link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68556502078083208854f7c82bfc14dc