### PR TITLE
Simplify authentication flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,8 @@
         <div class="task-input">
             <input type="text" id="auth-user" placeholder="Username" maxlength="30">
             <input type="password" id="auth-pass" placeholder="Password" maxlength="100">
-            <button class="add-btn" id="auth-btn">Sign Up</button>
+            <button class="add-btn" id="auth-btn">Log In / Sign Up</button>
         </div>
-        <div class="auth-toggle">Already have an account? <a href="#" id="auth-toggle-link">Log In</a></div>
     </div>
 
     <button id="logout" class="control-btn" style="display:none;">Log Out</button>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
     const authBtn = document.getElementById('auth-btn');
-    const authToggleLink = document.getElementById('auth-toggle-link');
-    let authMode = 'signup';
     const logoutBtn = document.getElementById('logout');
     const authBox = document.getElementById('auth');
     const matrixBox = document.getElementById('matrix');
@@ -24,7 +22,6 @@ document.addEventListener('DOMContentLoaded', () => {
     printBtn.addEventListener('click', () => window.print());
     clearBtn.addEventListener('click', clearAll);
     authBtn.addEventListener('click', authSubmit);
-    authToggleLink.addEventListener('click', toggleAuth);
     logoutBtn.addEventListener('click', logout);
 
     const lists = document.querySelectorAll('.task-list');
@@ -173,20 +170,19 @@ document.addEventListener('DOMContentLoaded', () => {
         const username = document.getElementById('auth-user').value.trim();
         const password = document.getElementById('auth-pass').value;
         if (!username || !password) return;
-        const url = authMode === 'signup' ? '/api/signup' : '/api/login';
-        const res = await fetch(url, {
+        let res = await fetch('/api/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username, password })
         });
+        if (!res.ok && res.status === 401) {
+            res = await fetch('/api/signup', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+        }
         if (res.ok) checkAuth();
-    }
-
-    function toggleAuth(e) {
-        e.preventDefault();
-        authMode = authMode === 'signup' ? 'login' : 'signup';
-        authBtn.textContent = authMode === 'signup' ? 'Sign Up' : 'Log In';
-        authToggleLink.textContent = authMode === 'signup' ? 'Log In' : 'Sign Up';
     }
 
     async function logout() {

--- a/style.css
+++ b/style.css
@@ -384,13 +384,3 @@ h1 {
     100% { transform: scale(1); }
 }
 
-.auth-toggle {
-    text-align: center;
-    margin-top: 10px;
-}
-
-.auth-toggle a {
-    color: #667eea;
-    text-decoration: none;
-    font-weight: 600;
-}


### PR DESCRIPTION
## Summary
- simplify auth flow so one button will login or signup as needed
- remove toggle link and unused CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685566f1e3948320b62080e2c3ff58d2