### PR TITLE
Add auth error messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
             <input type="password" id="auth-pass" placeholder="Password" maxlength="100">
             <button class="add-btn" id="auth-btn">Log In / Sign Up</button>
         </div>
+        <div id="auth-error" class="error-msg" style="display:none;"></div>
     </div>
 
     <button id="logout" class="control-btn" style="display:none;">Log Out</button>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const logoutBtn = document.getElementById('logout');
     const authBox = document.getElementById('auth');
     const matrixBox = document.getElementById('matrix');
+    const authError = document.getElementById('auth-error');
 
     const addBtn = document.getElementById('add-task');
     const input = document.getElementById('task-input');
@@ -141,6 +142,11 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function showAuthError(msg) {
+        authError.textContent = msg;
+        authError.style.display = msg ? '' : 'none';
+    }
+
     async function checkAuth() {
         const res = await fetch('/api/me');
         const data = await res.json();
@@ -148,11 +154,13 @@ document.addEventListener('DOMContentLoaded', () => {
             authBox.style.display = 'none';
             logoutBtn.style.display = '';
             matrixBox.style.display = '';
+            showAuthError('');
             loadTasks().then(renderTasks);
         } else {
             authBox.style.display = '';
             logoutBtn.style.display = 'none';
             matrixBox.style.display = 'none';
+            showAuthError('');
         }
     }
 
@@ -169,7 +177,10 @@ document.addEventListener('DOMContentLoaded', () => {
     async function authSubmit() {
         const username = document.getElementById('auth-user').value.trim();
         const password = document.getElementById('auth-pass').value;
-        if (!username || !password) return;
+        if (!username || !password) {
+            showAuthError('Username and password are required.');
+            return;
+        }
         let res = await fetch('/api/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -182,7 +193,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 body: JSON.stringify({ username, password })
             });
         }
-        if (res.ok) checkAuth();
+        if (res.ok) {
+            checkAuth();
+        } else {
+            let msg = 'Authentication failed.';
+            try { const data = await res.json(); if (data.error) msg = data.error; } catch (e) {}
+            showAuthError(msg);
+        }
     }
 
     async function logout() {

--- a/server.js
+++ b/server.js
@@ -53,9 +53,13 @@ app.get('/api/me', (req, res) => {
 
 app.post('/api/signup', (req, res) => {
   const { username, password } = req.body || {};
-  if (!username || !password) return res.status(400).end();
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required.' });
+  }
   const users = loadUsers();
-  if (users[username]) return res.status(400).end();
+  if (users[username]) {
+    return res.status(409).json({ error: 'User already exists.' });
+  }
   const hash = crypto.createHash('sha256').update(password).digest('hex');
   users[username] = hash;
   saveUsers(users);
@@ -65,10 +69,14 @@ app.post('/api/signup', (req, res) => {
 
 app.post('/api/login', (req, res) => {
   const { username, password } = req.body || {};
-  if (!username || !password) return res.status(400).end();
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password are required.' });
+  }
   const users = loadUsers();
   const hash = crypto.createHash('sha256').update(password).digest('hex');
-  if (users[username] !== hash) return res.status(401).end();
+  if (users[username] !== hash) {
+    return res.status(401).json({ error: 'Invalid username or password.' });
+  }
   req.session.user = username;
   res.status(204).end();
 });

--- a/style.css
+++ b/style.css
@@ -85,6 +85,12 @@ h1 {
     box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
 }
 
+.error-msg {
+    color: #e74c3c;
+    margin-top: 10px;
+    text-align: center;
+}
+
 .add-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);


### PR DESCRIPTION
## Summary
- show auth error information on the client
- style the auth error display
- return descriptive errors from login and signup endpoints

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68556836dafc8320bd6c393e92040d72