### PR TITLE
Add basic project feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create an account via the sign‑up form to start using TaskMatrix. Each user ha
 
 - Four quadrants: **DO NOW**, **PLAN**, **DELEGATE**, and **ELIMINATE**
 - Add tasks to any quadrant
+- Optional projects with custom icons to group tasks
 - Drag and drop tasks between quadrants
 - Reorder tasks within a quadrant using drag and drop
 - Delete tasks with the × button
@@ -41,6 +42,7 @@ Create an account via the sign‑up form to start using TaskMatrix. Each user ha
 - `script.js` – Front-end logic and drag-and-drop handling
 - `server.js` – Express server serving static files and saving tasks
 - `tasks.json` – Generated storage file for your tasks
+- `projects.json` – Generated storage file for your projects
 
 ## Contributing
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
     <div id="matrix" class="container" style="display:none;">
         <h1>Priority vs Urgency Matrix</h1>
 
+        <div class="project-input">
+            <input type="text" id="project-name" placeholder="Project name" maxlength="100">
+            <input type="text" id="project-icon" placeholder="Icon" maxlength="2">
+            <button class="add-btn" id="add-project">Add Project</button>
+        </div>
+
         <div class="task-input">
             <input type="text" id="task-input" placeholder="Enter a new task..." maxlength="200">
             <select id="quadrant-select">
@@ -29,6 +35,9 @@
                 <option value="plan">📅 PLAN (Important, Not Urgent)</option>
                 <option value="delegate">👥 DELEGATE (Urgent, Not Important)</option>
                 <option value="eliminate">🗑️ ELIMINATE (Not Urgent, Not Important)</option>
+            </select>
+            <select id="project-select">
+                <option value="">No Project</option>
             </select>
             <button class="add-btn" id="add-task">Add Task</button>
         </div>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,15 @@ h1 {
     justify-content: center;
 }
 
+.project-input {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+}
+
 .task-input input {
     flex: 1;
     min-width: 300px;
@@ -48,6 +57,23 @@ h1 {
     font-size: 16px;
     transition: all 0.3s ease;
     outline: none;
+}
+
+.project-input input {
+    flex: 1;
+    min-width: 200px;
+    padding: 15px 20px;
+    border: 2px solid #e0e0e0;
+    border-radius: 25px;
+    font-size: 16px;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.project-input input:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    transform: translateY(-2px);
 }
 
 .task-input input:focus {
@@ -240,6 +266,10 @@ h1 {
     align-items: center;
     word-break: break-word;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.task-project-icon {
+    margin-right: 8px;
 }
 
 .task:hover {


### PR DESCRIPTION
## Summary
- add project creation UI and project selector
- style new project elements and task project icons
- allow tasks to store an optional project ID in frontend and server
- persist user projects on the server
- document new project feature

## Testing
- `npm test` *(fails: Missing script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685569f139dc832083017ab9b756c3ad