### PR TITLE
Fix project UI layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -218,12 +218,21 @@ document.addEventListener('DOMContentLoaded', () => {
         projects.forEach(p => {
             const div = document.createElement('div');
             div.className = 'project-item';
-            const span = document.createElement('span');
-            span.textContent = `${p.icon ? p.icon + ' ' : ''}${p.name}`;
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'project-item-icon';
+            iconSpan.textContent = p.icon || '';
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'project-item-name';
+            nameSpan.textContent = p.name;
+
             const btn = document.createElement('button');
             btn.textContent = '\u00D7';
             btn.addEventListener('click', () => removeProject(p.id));
-            div.appendChild(span);
+
+            div.appendChild(iconSpan);
+            div.appendChild(nameSpan);
             div.appendChild(btn);
             projectList.appendChild(div);
         });

--- a/style.css
+++ b/style.css
@@ -77,6 +77,15 @@ h1 {
     margin-left: 5px;
 }
 
+.project-item-icon {
+    margin-right: 4px;
+}
+
+.project-item-name {
+    margin-right: 8px;
+    font-weight: 600;
+}
+
 .task-input input {
     flex: 1;
     min-width: 300px;
@@ -291,8 +300,8 @@ h1 {
     cursor: move;
     transition: all 0.3s ease;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 8px;
     word-break: break-word;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
@@ -304,6 +313,11 @@ h1 {
 .task-project-name {
     margin-right: 8px;
     font-weight: 600;
+}
+
+.task-text {
+    flex: 1;
+    overflow-wrap: anywhere;
 }
 
 .task:hover {
@@ -330,7 +344,8 @@ h1 {
     font-size: 14px;
     font-weight: bold;
     transition: all 0.3s ease;
-    margin-left: 10px;
+    margin-left: auto;
+    margin-right: 0;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- improve project list markup to show icon and title next to each other
- adjust task card flex layout so elements stay aligned
- ensure long task descriptions wrap without breaking layout

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68556fb5eaf883208704ca4b0a2a67f8